### PR TITLE
Add prompt caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ venv
 .vscode
 dist
 build
+.artefacts/

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# llm-claude-3
+# llm-claude-3-caching
 
 [![PyPI](https://img.shields.io/pypi/v/llm-claude-3.svg)](https://pypi.org/project/llm-claude-3/)
 [![Changelog](https://img.shields.io/github/v/release/simonw/llm-claude-3?include_prereleases&label=changelog)](https://github.com/simonw/llm-claude-3/releases)
 [![Tests](https://github.com/simonw/llm-claude-3/actions/workflows/test.yml/badge.svg)](https://github.com/simonw/llm-claude-3/actions/workflows/test.yml)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/simonw/llm-claude-3/blob/main/LICENSE)
 
-LLM access to Claude 3 by Anthropic
+A version of the llm-claude-3 plugin that supports caching. Forked from an older version, this branch does not support images or attachements.
 
 ## Installation
 
@@ -80,6 +80,7 @@ llm -c # continues from cached prompt, if available
 Prompt Caching is currently supported on:
 
 - Claude 3.5 Sonnet
+- claude 3.5 Haiku
 - Claude 3 Haiku
 - Claude 3 Opus
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ Run `llm models` to list the models, and `llm models --options` to include a lis
 
 Run prompts like this:
 ```bash
-llm -m claude-3.5-sonnet 'Fun facts about pelicans'
-llm -m claude-3-opus 'Fun facts about squirrels'
-llm -m claude-3-sonnet 'Fun facts about walruses'
-llm -m claude-3-haiku 'Fun facts about armadillos'
+llm -m claude-3.5-sonnet-cache 'Fun facts about pelicans' -o cache_prompt 1
+llm -m claude-3-opus-cache 'Fun facts about squirrels' -o cache_prompt 1
+llm -m claude-3-sonnet-cache 'Fun facts about walruses' -o cache_prompt 1
+llm -m claude-3-haiku-cache 'Fun facts about armadillos' -o cache_prompt 1
 ```
 
 ## Prompt Caching

--- a/README.md
+++ b/README.md
@@ -31,10 +31,63 @@ llm -m claude-3-sonnet 'Fun facts about walruses'
 llm -m claude-3-haiku 'Fun facts about armadillos'
 ```
 
-## New prompt caching option
-`-o cache_prompt 1` will cache user prompt
-`-o cache_system 1` will cache system prompt
+## Prompt Caching
 
+This plugin now supports Anthropic's Prompt Caching feature, which can significantly improve performance and reduce costs for certain types of queries.
+
+### How It Works
+
+Prompt Caching allows you to store and reuse context within your prompt. This is especially useful for:
+
+- Prompts with many examples
+- Large amounts of context or background information
+- Repetitive tasks with consistent instructions
+- Long multi-turn conversations
+
+The cache has a 5-minute lifetime, refreshed each time the cached content is used.
+
+### Usage
+
+To enable Prompt Caching, use the following options:
+
+- `-o cache_prompt 1`: Enables caching for the user prompt.
+- `-o cache_system 1`: Enables caching for the system prompt.
+
+Example:
+```bash
+llm -m claude-3-sonnet -o cache_prompt 1 'Analyze this text: [long text here]'
+llm -m claude-3-sonnet -o cache_prompt 1 -o cache_system 1 'Analyze this text: [long text here]' --system '[long system prompt here]'
+
+llm -c # continues from cached prompt, if available
+```
+
+### Benefits
+
+- Reduced latency: Can improve response times by over 2x.
+- Cost savings: Up to 90% reduction in costs for repetitive tasks.
+- Improved consistency: Helps maintain context across multiple queries.
+
+### Caching Behavior
+
+- The system checks if the prompt prefix is already cached from a recent query.
+- If found, it uses the cached version, reducing processing time and costs.
+- Otherwise, it processes the full prompt and caches the prefix for future use.
+
+### Supported Models
+
+Prompt Caching is currently supported on:
+
+- Claude 3.5 Sonnet
+- Claude 3 Haiku
+- Claude 3 Opus
+
+### Performance Tracking
+
+You can monitor cache performance using these fields in the API response:
+
+- `cache_creation_input_tokens`: Number of tokens written to the cache when creating a new entry.
+- `cache_read_input_tokens`: Number of tokens retrieved from the cache for this request.
+  
 ## Development
 
 To set up this plugin locally, first checkout the code. Then create a new virtual environment:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ LLM access to Claude 3 by Anthropic
 
 Install this plugin in the same environment as [LLM](https://llm.datasette.io/).
 ```bash
-llm install llm-claude-3
+git clone -b prompt-caching https://github.com/irthomasthomas/llm-claude-3-caching.git
+cd llm-claude-3-caching
+llm install -e .
 ```
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ llm -m claude-3-sonnet 'Fun facts about walruses'
 llm -m claude-3-haiku 'Fun facts about armadillos'
 ```
 
+## New prompt caching option
+`-o cache_prompt 1` will cache user prompt
+`-o cache_system 1` will cache system prompt
+
 ## Development
 
 To set up this plugin locally, first checkout the code. Then create a new virtual environment:

--- a/claude-docs.txt
+++ b/claude-docs.txt
@@ -1,0 +1,185 @@
+</docs>
+<example>
+    def __init__(self):
+        # Initialize an empty list to store conversation turns
+        self.turns = []
+
+    def add_turn_assistant(self, content):
+        # Add an assistant's turn to the conversation history
+        self.turns.append({
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "text",
+                    "text": content
+                }
+            ]
+        })
+
+    def add_turn_user(self, content):
+        # Add a user's turn to the conversation history
+        self.turns.append({
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": content
+                }
+            ]
+        })
+
+    def get_turns(self):
+        # Retrieve conversation turns with specific formatting
+        result = []
+        user_turns_processed = 0
+        # Iterate through turns in reverse order
+        for turn in reversed(self.turns):
+            if turn["role"] == "user" and user_turns_processed < 2:
+                # Add the last two user turns with ephemeral cache control
+                result.append({
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": turn["content"][0]["text"],
+                            "cache_control": {"type": "ephemeral"}
+                        }
+                    ]
+                })
+                user_turns_processed += 1
+            else:
+                # Add other turns as they are
+                result.append(turn)
+        # Return the turns in the original order
+        return list(reversed(result))
+
+# Initialize the conversation history
+conversation_history = ConversationHistory()
+
+# System message containing the book content
+# Note: 'book_content' should be defined elsewhere in the code
+system_message = f"<file_contents> {book_content} </file_contents>"
+
+# Predefined questions for our simulation
+questions = [
+    "What is the title of this novel?",
+    "Who are Mr. and Mrs. Bennet?",
+    "What is Netherfield Park?",
+    "What is the main theme of this novel?"
+]
+
+def simulate_conversation():
+    for i, question in enumerate(questions, 1):
+        print(f"\nTurn {i}:")
+        print(f"User: {question}")
+        
+        # Add user input to conversation history
+        conversation_history.add_turn_user(question)
+
+        # Record the start time for performance measurement
+        start_time = time.time()
+
+        # Make an API call to the assistant
+        response = client.messages.create(
+            model=MODEL_NAME,
+            extra_headers={
+              "anthropic-beta": "prompt-caching-2024-07-31"
+            },
+            max_tokens=300,
+            system=[
+                {"type": "text", "text": system_message, "cache_control": {"type": "ephemeral"}},
+            ],
+            messages=conversation_history.get_turns(),
+        )
+
+        # Record the end time
+        end_time = time.time()
+
+        # Extract the assistant's reply
+        assistant_reply = response.content[0].text
+        print(f"Assistant: {assistant_reply}")
+
+        # Print token usage information
+        input_tokens = response.usage.input_tokens
+        output_tokens = response.usage.output_tokens
+        input_tokens_cache_read = getattr(response.usage, 'cache_read_input_tokens', '---')
+        input_tokens_cache_create = getattr(response.usage, 'cache_creation_input_tokens', '---')
+        print(f"User input tokens: {input_tokens}")
+        print(f"Output tokens: {output_tokens}")
+        print(f"Input tokens (cache read): {input_tokens_cache_read}")
+        print(f"Input tokens (cache write): {input_tokens_cache_create}")
+
+        # Calculate and print the elapsed time
+        elapsed_time = end_time - start_time
+
+        # Calculate the percentage of input prompt cached
+        total_input_tokens = input_tokens + (int(input_tokens_cache_read) if input_tokens_cache_read != '---' else 0)
+        percentage_cached = (int(input_tokens_cache_read) / total_input_tokens * 100 if input_tokens_cache_read != '---' and total_input_tokens > 0 else 0)
+
+        print(f"{percentage_cached:.1f}% of input prompt cached ({total_input_tokens} tokens)")
+        print(f"Time taken: {elapsed_time:.2f} seconds")
+
+        # Add assistant's reply to conversation history
+        conversation_history.add_turn_assistant(assistant_reply)
+
+# Run the simulated conversation
+simulate_conversation()
+</example>
+
+<example>
+import anthropic
+client = anthropic.Anthropic()
+
+response = client.beta.prompt_caching.messages.create(
+    model="claude-3-5-sonnet-20241022",
+    max_tokens=1024,
+    system=[
+        {
+            "type": "text",
+            "text": "...long system prompt",
+            "cache_control": {"type": "ephemeral"}
+        }
+    ],
+    messages=[
+        # ...long conversation so far
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Hello, can you tell me more about the solar system?",
+                    "cache_control": {"type": "ephemeral"}
+                }
+            ]
+        },
+        {
+            "role": "assistant",
+            "content": "Certainly! The solar system is the collection of celestial bodies that orbit our Sun. It consists of eight planets, numerous moons, asteroids, comets, and other objects. The planets, in order from closest to farthest from the Sun, are: Mercury, Venus, Earth, Mars, Jupiter, Saturn, Uranus, and Neptune. Each planet has its own unique characteristics and features. Is there a specific aspect of the solar system you'd like to know more about?"
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Tell me more about Mars.",
+                    "cache_control": {"type": "ephemeral"}
+                }
+            ]
+        }
+    ]
+)
+In this example, we demonstrate how to use prompt caching in a multi-turn conversation.
+
+The cache_control parameter is placed on the system message to designate it as part of the static prefix.
+
+The conversation history (previous messages) is included in the messages array. The final turn is marked with cache-control, for continuing in followups. The second-to-last user message is marked for caching with the cache_control parameter, so that this checkpoint can read from the previous cache.
+
+This approach is useful for maintaining context in ongoing conversations without repeatedly processing the same information.
+
+For each request:
+
+input_tokens: Number of tokens in the new user message (will be minimal)
+cache_creation_input_tokens: Number of tokens in the new assistant and user turns
+cache_read_input_tokens: Number of tokens in the conversation up to the previous turn
+</example>
+</docs>

--- a/llm_chat_website_proposal.md
+++ b/llm_chat_website_proposal.md
@@ -1,0 +1,229 @@
+# LLM Consortium Chat Website Proposal
+
+## Overview
+
+This proposal outlines the development of a public-facing chat website that leverages the power of the LLM Consortium via the LLM Model Gateway. The website will provide users with an intuitive interface to interact with multiple language models simultaneously, benefiting from collaborative problem-solving and iterative refinement. The core functionality is based on the `ConsortiumOrchestrator` class, which will manage multiple models and guide iterative refinement using the `llm` library and `llm-consortium` plugin.
+
+## Key Features
+
+1.  **Multi-Model Chat Interface**
+    *   Clean, modern design inspired by popular chat interfaces, focused on ease of use and clear visual feedback.
+    *   Ability to interact with multiple language models simultaneously, with easy dynamic selection of models from a list of available models using the `llm` library.
+    *   Real-time streaming of responses from each model as they become available, using server-sent events (SSE) or WebSockets. The streaming will include the model name, the individual response, and the confidence level. If the `stream_individual_responses` option is enabled (similar to the `llm consortium` command line option), individual responses from each model will stream followed by the synthesized response, providing immediate feedback to the user.
+
+2.  **Consortium Orchestration**
+    *   Utilization of the LLM Consortium for collaborative problem-solving, managed by the `ConsortiumOrchestrator` class. The system will execute prompts against multiple models in parallel using `asyncio` for concurrent execution.
+    *   Iterative refinement of responses based on a configurable confidence threshold. The system will re-prompt the models if the confidence level is below the threshold, up to a `max_iterations` limit, as configured in the `ConsortiumConfig` model.
+    *   Transparent display of thought processes and confidence levels. Each model's response and confidence will be displayed during each iteration.
+    *   The arbiter model synthesizes responses using a specific arbiter prompt (defined in `arbiter_prompt.xml`), evaluates the confidence of the synthesized response, and identifies areas that may need further refinement. This process uses methods similar to `_synthesize_responses` and `_parse_arbiter_response`. The synthesizer will produce a JSON formatted response including the synthesis, confidence, analysis, dissenting views, and areas for refinement.
+
+3.  **Model Selection and Customization**
+    *   User-friendly interface to dynamically select models for the consortium, with options to save and load preferred model combinations using the `save`, `list`, `show`, and `remove` functionalities, mirroring the `llm consortium` commands. The saved configurations are managed using the `consortium_configs` table.
+    *   Ability to set custom parameters like `confidence_threshold` and `max_iterations` on a per-session basis, allowing users to control the refinement process. These parameters are similar to the command line options in the `llm consortium run` command.
+    *   Option to choose a specific arbiter model from the available `llm` models, allowing for flexibility and experimentation.
+    *   These custom parameters will be set in the UI, similar to the `llm consortium --option confidence_threshold=0.9 --option stream_individual_responses=true` command.
+
+4.  **Advanced Visualization**
+    *   Interactive visualization of the consortium process, showing the progression of the conversation, the individual model responses, the synthesized response, and the confidence scores at each step. The visualization will update in real-time as the consortium process unfolds.
+    *   **Agreement/Disagreement Highlighting:**
+        *   **Visual Cues:** Use color-coding (e.g., green for agreement, red for disagreement) to highlight words or phrases where models agree or disagree.
+        *   **Word Clouds:** Generate word clouds for each model, with font size corresponding to confidence or frequency of terms.
+        *   **Consensus Meter:** A visual meter that indicates the overall level of agreement among models.
+    *   **Confidence Tracking:**
+        *   **Line Graph:** A dynamic line graph showing the confidence level of the arbiter's synthesis after each iteration.
+        *   **Individual Model Confidence:** Display confidence scores for each model alongside their responses, possibly using bar graphs or color-coded indicators.
+    *    **Refinement Areas:**
+         *  Clearly display the "refinement_areas" identified by the arbiter after each iteration. These areas will be highlighted in the synthesized response and can be used to guide further questioning or adjustments to the consortium's parameters.
+
+5.  **User Management and History**
+    *   User registration and authentication system using JWT with OAuth support.
+    *   Saving and exporting of chat histories in various formats (JSON). The complete history, including individual model responses, synthesis data, and metadata, will be stored in the database.
+    *   Personal dashboard with usage statistics and saved model combinations. Users will be able to view their usage of specific models and consortium configurations, leveraging the data stored in the `consortium_configs` table.
+
+6.  **Performance and Scalability**
+    *   Integration with LLM Model Gateway for efficient model routing and management of API keys/authentication.
+    *   Caching mechanism to reduce redundant API calls, enhancing speed for repetitive requests. This will include response caching and partial result memoization.
+    *   Load balancing and fallback strategies for high availability. The system will employ distributed model request routing and automatic model fallback mechanisms.
+
+7.  **Admin Panel and Analytics**
+    *   Comprehensive logging and analytics dashboard for monitoring the usage of the service using `sqlite_utils` to log all interactions and system events, similar to how the `llm-consortium` plugin logs its data.
+    *   Ability to monitor and analyze model performance and usage patterns via logs.
+    *   Tools for managing user accounts and system configurations.
+
+## Enhanced Architecture Overview
+
+### Core System Design
+
+The LLM Consortium Chat Website will be a sophisticated platform leveraging multiple language models through an intelligent orchestration system. Drawing from the Karpathy Consortium's design, the system will feature:
+
+1.  **Multi-Model Collaborative Processing**
+    *   Parallel model response generation using `asyncio`.
+    *   Real-time confidence tracking.
+    *   Iterative refinement mechanism based on a configurable threshold.
+    *   Dynamic arbiter model selection.
+
+2.  **Architectural Components**
+    *   Frontend: React.js with TypeScript for building a modern and interactive user interface.
+    *   Backend: Node.js with Express.js and WebSocket support for API handling and real-time communication.
+    *   Model Gateway: Enhanced LLM Model Router for routing requests.
+    *   Caching Layer: Redis for response memoization.
+    *   Logging: Advanced SQLite system for logging all interactions. The logging uses `sqlite_utils` to store all data.
+
+### Enhanced Technical Specifications
+
+#### Model Orchestration Engine
+
+```typescript
+interface ModelOrchestrationConfig {
+  models: string[];
+  confidenceThreshold: number;
+  maxIterations: number;
+  arbiterModel: string;
+  systemPrompt?: string;
+}
+
+class ConsortiumOrchestrator {
+  private models: string[];
+  private confidenceThreshold: number;
+
+  async orchestrate(prompt: string): Promise<ConsortiumResponse> {
+    // Parallel model querying
+    // Iterative refinement
+    // Confidence-based synthesis
+  }
+}
+```
+
+The `ChatSession` class encapsulates a single chat session with a user.
+It initializes a `ConsortiumOrchestrator` instance with the user's chosen configuration.
+The `handlePrompt` method uses the orchestrator to process the user's prompt and returns the synthesized response.
+The `ConsortiumOrchestrator` class, as defined in `__init__.py`, handles the core logic of sending prompts to models, managing iterations, and synthesizing responses.
+
+## Technology Stack
+
+*   **Frontend:** React.js with TypeScript for a robust and maintainable user interface.
+*   **Backend:** Node.js with Express.js for efficient API handling and server-side logic.
+*   **Database:** SQLite for user data and chat history, SQLite for logging (consistent with the LLM Consortium's logging) and user configurations. The logging will be implemented using `sqlite_utils`.
+*   **API Gateway:** LLM Model Gateway for routing requests to the LLM Consortium, handling authentication, and managing API keys.
+*   **Authentication:** JWT with OAuth support for secure user authentication.
+*   **Deployment:** Docker containers with Kubernetes orchestration for scalability and ease of deployment.
+*   **Monitoring:** Prometheus and Grafana for system metrics, performance monitoring, and alerting.
+*   **LLM Library:** The system is built using the `llm` library which provides core functionality and will utilize the `llm-consortium` plugin for orchestration and model interaction.
+
+## Development Phases
+
+1.  **Phase 1: Core Infrastructure** (6 weeks)
+    *   Implement model gateway and basic consortium orchestration logic using `asyncio` with the `ConsortiumOrchestrator` class.
+    *   Set up project structure, development environment, and initial user authentication.
+2.  **Phase 2: User Experience** (4 weeks)
+    *   Develop advanced visualization components for the chat interface showing individual model responses, the synthesized response, and the confidence scores.
+    *   Develop the different interaction modes for different use cases.
+    *   Create a responsive design for different screen sizes.
+3.  **Phase 3: Advanced Features** (4 weeks)
+    *   Implement machine learning model recommendations for model selection.
+    *   Implement enhanced security features.
+    *   Optimize for performance.
+
+## Performance Optimization Strategies
+
+### Caching Mechanisms
+
+*   Response caching with intelligent expiration to ensure the most up-to-date information is used.
+*   Partial result memoization for repeated queries.
+*   Intelligent cache invalidation strategies.
+*   Model-specific caching configurations to cater to specific model needs.
+
+### Load Balancing
+
+*   Distributed model request routing to distribute requests evenly.
+*   Automatic model fallback mechanisms for handling model failures.
+*   Rate limiting and quota management to maintain system stability.
+*   Geographic model endpoint selection for optimal performance.
+
+## Security and Compliance Framework
+
+### Authentication Layers
+
+*   Multi-factor authentication for added security.
+*   OAuth 2.0 and OpenID Connect support.
+*   Granular permission management to control access to various resources.
+*   Anonymous/guest interaction options.
+
+### Data Privacy Controls
+
+*   End-to-end encryption for sensitive queries.
+*   Configurable data retention policies to meet compliance requirements.
+*   Anonymization of model interactions.
+*   Comprehensive audit logging.
+
+## User Flow
+
+1.  User visits the website and registers or logs in.
+2.  User creates a new chat session or loads a saved configuration from the `consortium_configs` table.
+3.  User selects models for the consortium or chooses a predefined combination. The model selection interface will expose the same models available in the `llm` library. The user will be able to configure the confidence threshold, the maximum iterations, and the arbiter model, using the same parameters used in the `llm consortium` command line.
+4.  User inputs their query. The prompt is sent using an XML formatted prompt `<prompt><instruction>{prompt}</instruction></prompt>`, consistent with the `llm-consortium` plugin.
+5.  System orchestrates the consortium process:
+    *   Sends the prompt to selected models using the `llm` library with `asyncio` for concurrent execution.
+    *    Displays streaming responses from each model in real-time with respective confidence scores. If the `stream_individual_responses` option is enabled, each model's response will stream individually, followed by the synthesized response. The UI will also indicate the current iteration number.
+   *   Visualizes thought processes and confidence levels during each iteration, providing real-time feedback to the user.
+    *   The arbiter model synthesizes responses based on a formatted arbiter prompt including previous iteration history and areas for refinement. This process follows the logic described in the `_synthesize_responses` method.
+    *   Performs iterative refinement based on the confidence threshold and max iterations parameters using the `ConsortiumOrchestrator` class.
+
+6.  User receives a final synthesized response.
+    *   The final result is a JSON formatted output similar to the following:
+
+    ```json
+    {
+        "original_prompt": "What are the key considerations for AGI safety?",
+        "model_responses": [
+            {
+                "model": "claude-3-opus-20240229",
+                "response": "<thought_process> ... </thought_process> <answer> ... </answer> <confidence> 0.85 </confidence>",
+                "confidence": 0.85
+            },
+            {
+                "model": "claude-3-sonnet-20240229",
+                 "response": "<thought_process> ... </thought_process> <answer> ... </answer> <confidence> 0.78 </confidence>",
+                "confidence": 0.78
+            },
+            {
+                "model": "gpt-4",
+                 "response": "<thought_process> ... </thought_process> <answer> ... </answer> <confidence> 0.9 </confidence>",
+                "confidence": 0.9
+            },
+            {
+                "model": "gemini-pro",
+                 "response": "<thought_process> ... </thought_process> <answer> ... </answer> <confidence> 0.7 </confidence>",
+                 "confidence": 0.7
+            }
+        ],
+         "synthesis": {
+            "synthesis": "The key considerations for AGI safety are...",
+            "confidence": 0.92,
+            "analysis": "The models largely agree on the importance of alignment...",
+            "dissent": "Model Gemini-Pro was less confident...",
+             "needs_iteration": false,
+            "refinement_areas": ["Explore the concept of alignment further", "Investigate different safety frameworks"]
+         },
+        "metadata": {
+            "models_used": [
+                 "claude-3-opus-20240229",
+                 "claude-3-sonnet-20240229",
+                 "gpt-4",
+                 "gemini-pro"
+              ],
+            "arbiter": "claude-3-opus-20240229",
+            "timestamp": "2024-07-26T12:00:00.000000",
+            "iteration_count": 2
+            }
+    }
+    ```
+7.  User can save the chat, adjust parameters, or start a new query.
+
+## Error Handling
+
+The website will handle errors gracefully, including network issues, model failures, and parsing errors. If a model fails, the error will be logged using the `log_response` function, and the system will continue with the remaining models if possible. If parsing of the arbiter's response fails, the raw response will be shown to the user along with a warning. If the underlying system fails, the user will be notified, and the error will be logged in the `sqlite_utils` database.
+
+## Conclusion
+
+This proposal outlines a comprehensive plan to develop an innovative chat website that leverages the power of the LLM Consortium through the LLM Model Gateway. By focusing on multi-model collaboration, interactive visualization, user customization, and a robust underlying architecture, we aim to create a unique and powerful platform for AI-assisted problem-solving and exploration. This website will not only showcase the capabilities of the LLM Consortium but also provide a valuable tool for researchers, developers, and anyone interested in exploring the potential of large language models. The detailed integration with the `llm-consortium` plugin, including dynamic model selection, saved consortiums, and advanced visualization, will offer a cutting-edge experience for users. The website will be heavily reliant on the `llm` library and the `llm-consortium` plugin for core functionality.

--- a/llm_claude_3.py
+++ b/llm_claude_3.py
@@ -12,6 +12,10 @@ def register_models(register):
     register(ClaudeMessages("claude-3-haiku-20240307"), aliases=("claude-3-haiku",))
     register(ClaudeMessagesLong("claude-3-5-sonnet-20240620"), aliases=("claude-3.5-sonnet",))
     register(ClaudeMessagesLong("claude-3-5-haiku-latest"), aliases=("claude-3.5-haiku",))
+    # claude-3-5-sonnet-20241022
+    register(ClaudeMessagesLong("claude-3-5-sonnet-20241022"), aliases=("claude-3.5-sonnet","new-sonnet",))
+    # claude-3-5-haiku-latest
+    register(ClaudeMessagesLong("claude-3-5-haiku-latest"), aliases=("claude-3.5-haiku",))
 
 
 class ClaudeOptions(llm.Options):

--- a/llm_claude_3_cache.py
+++ b/llm_claude_3_cache.py
@@ -7,15 +7,15 @@ from typing import Optional, List
 @llm.hookimpl
 def register_models(register):
     # https://docs.anthropic.com/claude/docs/models-overview
-    register(ClaudeMessages("claude-3-opus-20240229"), aliases=("claude-3-opus",))
-    register(ClaudeMessages("claude-3-sonnet-20240229"), aliases=("claude-3-sonnet",))
-    register(ClaudeMessages("claude-3-haiku-20240307"), aliases=("claude-3-haiku",))
-    register(ClaudeMessagesLong("claude-3-5-sonnet-20240620"), aliases=("claude-3.5-sonnet",))
-    register(ClaudeMessagesLong("claude-3-5-haiku-latest"), aliases=("claude-3.5-haiku",))
+    register(ClaudeMessages("claude-3-opus-20240229"), aliases=("claude-3-opus-cache",))
+    register(ClaudeMessages("claude-3-sonnet-20240229"), aliases=("claude-3-sonnet-cache",))
+    register(ClaudeMessages("claude-3-haiku-20240307"), aliases=("claude-3-haiku-cache",))
+    register(ClaudeMessagesLong("claude-3-5-sonnet-20240620"), aliases=("claude-3.5-sonnet-cache",))
+    register(ClaudeMessagesLong("claude-3-5-haiku-latest"), aliases=("claude-3.5-haiku-cache",))
     # claude-3-5-sonnet-20241022
-    register(ClaudeMessagesLong("claude-3-5-sonnet-20241022"), aliases=("claude-3.5-sonnet","new-sonnet",))
+    register(ClaudeMessagesLong("claude-3-5-sonnet-20241022"), aliases=("claude-3.5-sonnet","new-sonnet-cache",))
     # claude-3-5-haiku-latest
-    register(ClaudeMessagesLong("claude-3-5-haiku-latest"), aliases=("claude-3.5-haiku",))
+    register(ClaudeMessagesLong("claude-3-5-haiku-latest"), aliases=("claude-3.5-haiku-cache",))
 
 
 class ClaudeOptions(llm.Options):
@@ -175,7 +175,7 @@ class ClaudeMessages(llm.Model):
                 # This records usage and other data:
                 response.response_json = stream.get_final_message().model_dump()
         else:
-            completion = client.beta.prompt_caching.messages.create(**kwargs)
+            completion = client.messages.create(**kwargs)
             yield completion.content[0].text
             response.response_json = completion.model_dump()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "llm-claude-3"
+name = "llm-claude-caching"
 version = "0.4.1"
 description = "LLM access to Claude 3 by Anthropic"
 readme = "README.md"
@@ -20,7 +20,7 @@ Issues = "https://github.com/simonw/llm-claude-3/issues"
 CI = "https://github.com/simonw/llm-claude-3/actions"
 
 [project.entry-points.llm]
-claude_3 = "llm_claude_3"
+claude_3_cache = "llm_claude_3_cache"
 
 [project.optional-dependencies]
 test = ["pytest", "pytest-recording"]


### PR DESCRIPTION
- Introduced new caching options for user and system prompts in the ClaudeOptions class.

Files changed:
- llm_claude_3.py:
  - Added cache_prompt and cache_system options to ClaudeOptions.
  - Modified message handling in ClaudeMessages to support caching functionality.
  - Updated response processing to include cache control mechanisms.
- README.md: Added new section on caching options and usage.
 
I do not think that I like the interface, tbh, but see what you think. It's hard to trade off features and complexity. 
I did not think that caching should be turned on by default, due to the 25% premium on cache inputs.
This first implementation is less flexible than the API allows. The API allows for you to include both cached and none-cached system and user prompts in one request. I wasn't sure how to do that without editing the main projects cli.py?

I think ideally the interface would be 
llm --system "not cached system prompt" --cached-system "this system prompt will be cached" --cached-user "a user prompt to be cached" "none cached prompt?"
But how do we handle the case of requesting ONLY a cached user prompt? I think the current cli demands a prompt, so that would need updating.

Anyway, here is the current implementation.
To use it, you use prompt and --system as normal, and then you can choose to cache or not cache either one by adding -o cache_prompt 1 and/or -o cache_system 1 
Then you get cache metadata returned in the json. 

Added option `cache_prompt` and `cache_system` 

To use 
```bash
llm -m claude-3.5-sonnet --system $(cat long-system.txt) "prompt" -o cache_system 1
```

"usage": {"input_tokens": 10000, "output_tokens": 500, "cache_creation_input_tokens": 10000, "cache_read_input_tokens": 0}}

This first prompt requests to cache the system prompt. I used a file of 10,000 tokens, and as this is the first prompt we see "cache_creation_input_tokens": 10000 returned in the json. This means we paid 25% more for those tokens, but future requests using the same system prompt will be discounted 90%, as long we re-prompt within the cache TTL, currently 5 minutes (refreshed each time).

```bash
llm -m claude-3.5-sonnet --system $(cat long-system.txt) "a new non-cached user prompt. " -o cache_system 1
```

 "usage": {"input_tokens": 10001, "output_tokens": 500, "cache_creation_input_tokens": 0, "cache_read_input_tokens":10000 }}

This sends a new user prompt but the same system prompt, along with the cache_system flag this means we will use the cached system prompt from the previous command. We can see we hit the cache by the usage response: "cache_read_input_tokens":10000 

```bash
llm -m claude-3.5-sonnet --system $(cat long-system.txt) "$(cat long-prompt.txt)" -o cache_system 1 -o cache_prompt 1
```

 "usage": {"input_tokens": 15000 "output_tokens": 500, "cache_creation_input_tokens": 5000, "cache_read_input_tokens":10000 }}

This time we CREATE a USER prompt cache, and also READ a SYSTEM cache. Hence: 
 "cache_creation_input_tokens": 5000, "cache_read_input_tokens":10000

```bash
llm -m claude-3.5-sonnet --system $(cat long-system.txt) "$(cat long-prompt.txt)" -o cache_system 1 -o cache_prompt 1
```

 "usage": {"input_tokens": 15000 "output_tokens": 500, "cache_creation_input_tokens": 0, "cache_read_input_tokens" :15000

Finally, running the same command again causes both system and user prompt cache reads.