### PR TITLE
Assistant prefill and stop_sequences async

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,15 @@ Images are supported too:
 llm -m claude-3.5-sonnet 'describe this image' -a https://static.simonwillison.net/static/2024/pelicans.jpg
 llm -m claude-3-haiku 'extract text' -a page.png
 ```
-
+Prefill assistant response:
+```bash
+llm -m claude-3-opus "Extract name and price from: $description" -o prefill "{"
+```
+```json
+“name”: “SmartHome Mini”,
+“price”: “$49.99”
+}
+```
 ## Development
 
 To set up this plugin locally, first checkout the code. Then create a new virtual environment:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ llm -m claude-3-opus "Extract name and price from: $description" -o prefill "{"
 “price”: “$49.99”
 }
 ```
+Stop Sequences (comma separated list):
+```bash
+llm -m claude-3-opus "List files sorted by modification time (be brief)" -o prefill "<code>" -o stop_sequences "</code>"
+```
+```
+ls -lt
+```
+
 ## Development
 
 To set up this plugin locally, first checkout the code. Then create a new virtual environment:

--- a/llm_claude_3.py
+++ b/llm_claude_3.py
@@ -48,6 +48,11 @@ def register_models(register):
 
 
 class ClaudeOptions(llm.Options):
+    prefill: Optional[str] = Field(
+        description="Text to prefill the assistant's response. The model will continue from this text.",
+        default=None,
+    )
+
     max_tokens: Optional[int] = Field(
         description="The maximum number of tokens to generate before stopping",
         default=4_096,
@@ -205,6 +210,11 @@ class _Shared:
             )
         else:
             messages.append({"role": "user", "content": prompt.prompt})
+        if prompt.options.prefill:
+            messages.append({
+                "role": "assistant",
+                "content": prompt.options.prefill
+            })
         return messages
 
     def build_kwargs(self, prompt, conversation):

--- a/tests/cassettes/test_claude_3/test_async_prefill.yaml
+++ b/tests/cassettes/test_claude_3/test_async_prefill.yaml
@@ -1,0 +1,136 @@
+interactions:
+- request:
+    body: '{"max_tokens": 4096, "messages": [{"role": "user", "content": "Two names
+      for a pet pelican, be brief"}, {"role": "assistant", "content": "{"}], "model":
+      "claude-3-opus-latest", "temperature": 1.0, "stream": true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '212'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.39.0
+      x-stainless-arch:
+      - x64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Linux
+      x-stainless-package-version:
+      - 0.39.0
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.12.7
+      x-stainless-stream-helper:
+      - messages
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"id":"msg_012vCise8tDpbuqADFiPthb6","type":"message","role":"assistant","model":"claude-3-opus-20240229","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":18,"output_tokens":1}}           }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}      }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"outputs"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"}\n\n1.
+        P"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"elly\n2."}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Beaky"}     }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0          }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":17}    }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"          }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8e5182d5fedc385e-LHR
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 19 Nov 2024 16:17:33 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-requests-limit:
+      - '2000'
+      anthropic-ratelimit-requests-remaining:
+      - '1999'
+      anthropic-ratelimit-requests-reset:
+      - '2024-11-19T16:17:33Z'
+      anthropic-ratelimit-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-tokens-remaining:
+      - '76000'
+      anthropic-ratelimit-tokens-reset:
+      - '2024-11-19T16:17:36Z'
+      request-id:
+      - req_01KbqMPuxogidvrSo9omznu1
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_claude_3/test_async_stop_sequence.yaml
+++ b/tests/cassettes/test_claude_3/test_async_stop_sequence.yaml
@@ -1,0 +1,126 @@
+interactions:
+- request:
+    body: '{"max_tokens": 4096, "messages": [{"role": "user", "content": "List files
+      sorted by modification time (be brief)"}, {"role": "assistant", "content": "<code>"}],
+      "model": "claude-3-opus-latest", "stop_sequences": ["</code>"], "temperature":
+      1.0, "stream": true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '260'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.39.0
+      x-stainless-arch:
+      - x64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Linux
+      x-stainless-package-version:
+      - 0.39.0
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.12.7
+      x-stainless-stream-helper:
+      - messages
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"id":"msg_01YT6hxu68PJmfw9khjdpmzt","type":"message","role":"assistant","model":"claude-3-opus-20240229","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":20,"output_tokens":1}}       }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}   }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ls"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        -lth"} }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0         }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"stop_sequence","stop_sequence":"</code>"},"usage":{"output_tokens":7}               }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"       }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8e5184da98cd88bc-LHR
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 19 Nov 2024 16:18:56 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-requests-limit:
+      - '2000'
+      anthropic-ratelimit-requests-remaining:
+      - '1999'
+      anthropic-ratelimit-requests-reset:
+      - '2024-11-19T16:18:56Z'
+      anthropic-ratelimit-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-tokens-remaining:
+      - '76000'
+      anthropic-ratelimit-tokens-reset:
+      - '2024-11-19T16:18:59Z'
+      request-id:
+      - req_01NCyCHMUfAf6DKJfUiKHuqK
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_claude_3/test_prefill.yaml
+++ b/tests/cassettes/test_claude_3/test_prefill.yaml
@@ -1,0 +1,142 @@
+interactions:
+- request:
+    body: '{"max_tokens": 4096, "messages": [{"role": "user", "content": "Two names
+      for a pet pelican, be brief"}, {"role": "assistant", "content": "{"}], "model":
+      "claude-3-opus-latest", "temperature": 1.0, "stream": true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '212'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.39.0
+      x-stainless-arch:
+      - x64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Linux
+      x-stainless-package-version:
+      - 0.39.0
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.12.7
+      x-stainless-stream-helper:
+      - messages
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"id":"msg_01KXLLcmFbfQi6kwhb4pfoYK","type":"message","role":"assistant","model":"claude-3-opus-20240229","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":18,"output_tokens":2}}       }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}   }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\nResult"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":":
+        1"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":".
+        Pelly"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        2. Be"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"aky\n}"}            }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0              }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":20}             }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"              }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8e5134f4b94dcd38-LHR
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 19 Nov 2024 15:24:23 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-requests-limit:
+      - '2000'
+      anthropic-ratelimit-requests-remaining:
+      - '1999'
+      anthropic-ratelimit-requests-reset:
+      - '2024-11-19T15:24:23Z'
+      anthropic-ratelimit-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-tokens-remaining:
+      - '76000'
+      anthropic-ratelimit-tokens-reset:
+      - '2024-11-19T15:24:26Z'
+      request-id:
+      - req_011NchvF36mJwpdPUsTAV6xz
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_claude_3/test_stop_sequence.yaml
+++ b/tests/cassettes/test_claude_3/test_stop_sequence.yaml
@@ -1,0 +1,126 @@
+interactions:
+- request:
+    body: '{"max_tokens": 4096, "messages": [{"role": "user", "content": "List files
+      sorted by modification time (be brief)"}, {"role": "assistant", "content": "<code>"}],
+      "model": "claude-3-opus-latest", "stop_sequences": ["</code>"], "temperature":
+      1.0, "stream": true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '260'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.39.0
+      x-stainless-arch:
+      - x64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Linux
+      x-stainless-package-version:
+      - 0.39.0
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.12.7
+      x-stainless-stream-helper:
+      - messages
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"id":"msg_016zF3GJHKje3rh8nQQAgbFC","type":"message","role":"assistant","model":"claude-3-opus-20240229","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":20,"output_tokens":1}}           }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}       }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ls"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        -lth"}   }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0  }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"stop_sequence","stop_sequence":"</code>"},"usage":{"output_tokens":7}         }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"             }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8e517e1a9c8fbea1-LHR
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 19 Nov 2024 16:14:20 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-requests-limit:
+      - '2000'
+      anthropic-ratelimit-requests-remaining:
+      - '1999'
+      anthropic-ratelimit-requests-reset:
+      - '2024-11-19T16:14:19Z'
+      anthropic-ratelimit-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-tokens-remaining:
+      - '76000'
+      anthropic-ratelimit-tokens-reset:
+      - '2024-11-19T16:14:22Z'
+      request-id:
+      - req_01HvSV85zfYzBEaBGyLbNZuo
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_claude_3.py
+++ b/tests/test_claude_3.py
@@ -35,6 +35,15 @@ def test_prompt():
 
 
 @pytest.mark.vcr
+def test_prefill():
+    model = llm.get_model("claude-3-opus")
+    model.key = model.key or ANTHROPIC_API_KEY
+    response = model.prompt("Two names for a pet pelican, be brief", prefill="{")
+    # assert "}" in response:
+    assert "}" in str(response)
+        
+    
+@pytest.mark.vcr
 @pytest.mark.asyncio
 async def test_async_prompt():
     model = llm.get_async_model("claude-3-opus")


### PR DESCRIPTION
## Changes
- Updated model implementation to support `stop_sequences` parameter
- Added `prefill` option to prefill Claude's response
- Updated README with documentation for new features

## Testing
- Verified functionality with claude-3-opus
- Tested stop sequences and prefill behavior

## Notes
Neither the prefill, nor the stop_sequence are included in the response.
```bash
llm -m claude-3-opus  "List files sorted by modification time (be brief)" \
-o prefill "<code>" \
-o stop_sequences "</code>,\n"
```
```
ls -lt
```
### response_json
```json
"stop_reason": "stop_sequence", "stop_sequence": "</code>"
```